### PR TITLE
[NOTRACER] External implementations drive uberTraceID

### DIFF
--- a/src/eenmediaplayer.js
+++ b/src/eenmediaplayer.js
@@ -116,7 +116,7 @@ function startPlayback(config, element) {
         enableStashBuffer: !isLive,
         type: 'flv',
         eventLogger: config.event_logger,
-        uberTraceID: `${random128BitInHex()}:${random64BitInHex()}:0:1`
+        uberTraceID: config.uberTraceID
     };
 
     if (config.options)


### PR DESCRIPTION
Updated so that external implementers will tell the media player through
config to do distributed tracing.

Dependency for:
https://github.com/EENCloud/frontend-gui/pull/2340