### PR TITLE
[EEPD-41748] use doubled normalized speed for size of stashSizeKB and…

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -25,7 +25,7 @@ export const defaultConfig = {
 
     lazyLoad: true,
     lazyLoadMaxDuration: 3 * 60,
-    lazyLoadRecoverDuration: 30,
+    lazyLoadRecoverDuration: 4 * 60,
     deferLoadAfterSourceOpen: true,
 
     // autoCleanupSourceBuffer: default as false, leave unspecified

--- a/src/eenmediaplayer.js
+++ b/src/eenmediaplayer.js
@@ -116,7 +116,9 @@ function startPlayback(config, element) {
         enableStashBuffer: !isLive,
         type: 'flv',
         eventLogger: config.event_logger,
-        uberTraceID: config.uberTraceID
+        uberTraceID: config.uberTraceID,
+        enableNewStashSizeInHb: !!config.enable_new_stash_size_in_hb,
+        lazyLoadRecoverDuration: config.enable_new_stash_size_in_hb ? 4 * 60 : 30
     };
 
     if (config.options)
@@ -174,6 +176,7 @@ class MediaItem {
         this.url = null;
         this.event_logger = null;
         this.domain  = window.location.host;
+        this.enable_new_stash_size_in_hb = false;
     }
 
     setEventLogger(logger) {

--- a/src/io/io-controller.js
+++ b/src/io/io-controller.js
@@ -413,8 +413,16 @@ class IOController {
         if (this._config.isLive) {
             // live stream: always use single normalized speed for size of stashSizeKB
             stashSizeKB = normalized;
-        } else {
+        } else if (this._config.enableNewStashSizeInHb) {
             stashSizeKB = normalized * 2;
+        } else {
+            if (normalized < 512) {
+                stashSizeKB = normalized * 4.0 * this.element.playbackRate;
+            } else if (normalized >= 512 && normalized <= 1024) {
+                stashSizeKB = Math.floor(normalized * 1.5) * 5.0 * this.element.playbackRate;
+            } else {
+                stashSizeKB = normalized * 4.0 * this.element.playbackRate;
+            }
         }
 
         let bufferSize = stashSizeKB * 1024 + 1024 * 1024 * 2.0;  // stashSize + 1MB

--- a/src/io/io-controller.js
+++ b/src/io/io-controller.js
@@ -414,13 +414,7 @@ class IOController {
             // live stream: always use single normalized speed for size of stashSizeKB
             stashSizeKB = normalized;
         } else {
-            if (normalized < 512) {
-                stashSizeKB = normalized * 4.0 * this.element.playbackRate;
-            } else if (normalized >= 512 && normalized <= 1024) {
-                stashSizeKB = Math.floor(normalized * 1.5) * 5.0 * this.element.playbackRate;
-            } else {
-                stashSizeKB = normalized * 4.0 * this.element.playbackRate;
-            }
+            stashSizeKB = normalized * 2;
         }
 
         let bufferSize = stashSizeKB * 1024 + 1024 * 1024 * 2.0;  // stashSize + 1MB


### PR DESCRIPTION
## Jira:
[EEPD-41748] 

## Done:
- use doubled normalized speed for size of stashSizeKB 
- increased lazyLoadRecoverDuration time

## Related PR
https://github.com/EENCloud/frontend-gui/pull/3568

[EEPD-41724]: https://eagleeyenetworks.atlassian.net/browse/EEPD-41724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EEPD-41748]: https://eagleeyenetworks.atlassian.net/browse/EEPD-41748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ