### PR TITLE
Add: JWT support

### DIFF
--- a/src/eenmediaplayer.js
+++ b/src/eenmediaplayer.js
@@ -128,6 +128,10 @@ function startPlayback(config, element) {
         options['eventLogger'] = config.event_logger;
     }
 
+    if (config.jwt) {
+        options['headers'] = { 'Authorization': 'bearer ' + config.jwt };
+    }
+
     let player = createPlayer(options, options);
     player.attachMediaElement(element);
     player.load();


### PR DESCRIPTION
If a JWT is provided in the config, it will be added in the request authorization header as bearer token.