### PR TITLE
Add compass.yml (adopt Compass component as config-as-code)

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -1,0 +1,8 @@
+name: Flv Js
+id: ari:cloud:compass:4337fc0d-aa55-4ff9-bd75-ef7117ff9381:component/4c6fdffe-fa4a-46ef-9e6f-a1aa05480c89/235f9146-7d7b-4ffb-8410-267f254d94e3
+configVersion: 1
+typeId: LIBRARY
+ownerId: ari:cloud:identity::team/02623aed-f05b-4acd-8187-7932552722de-17 # VMS Experience (320)
+links:
+  - type: REPOSITORY
+    url: https://github.com/EENCloud/flv.js


### PR DESCRIPTION
## Adopt Compass component as config-as-code

Adds `compass.yml` binding **flv.js** to its existing Compass component **Flv Js** (`LIBRARY`, owner VMS Experience (320)). This moves the component from manually-managed to config-as-code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)